### PR TITLE
refactor: remove explicit env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,7 @@ AWS Lambda that creates CARv2 side indexes for CAR files uploaded to an S3 bucke
 
 <img src="https://user-images.githubusercontent.com/152863/172424487-9d4d09df-df33-4fa1-a483-ff6565047bd6.png" width="471"/>
 
-## Deployment Environment Variables
-
-| Name                         | Default | Description            |
-| ---------------------------- | ------- | ---------------------- |
-| AWS_ACCESS_KEY_ID            |         | The AWS key ID.        |
-| AWS_SECRET_ACCESS_KEY        |         | The AWS secret key.    |
-| AWS_SESSION_TOKEN            |         | The AWS Session token. |
-
-Note: The Lambda needs `GetObject` and `PutObject` access on the bucket it is deployed on.
+Note: The Lambda needs a policy with `GetObject` and `PutObject` access to the bucket it is deployed on.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -16,14 +16,7 @@ exports.handler = async function handler (event, context) {
     .filter(r => r.s3.object.key.endsWith('.car'))
 
   for (const r of records) {
-    const s3 = new S3({
-      region: r.awsRegion,
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN
-      }
-    })
+    const s3 = new S3({ region: r.awsRegion })
 
     const getCmd = new GetObjectCommand({
       Bucket: r.s3.bucket.name,


### PR DESCRIPTION
The SDK extracts these from the environment automatically so this is not required.