### PR TITLE
refactor: subscribe to SNS and consume S3 events wrapped in SNS events

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function toS3Event (snsEvent) {
         s3Event.Records.push(s3Rec)
       }
     } catch (err) {
-      console.error(`failed to extract S3Event record from SNSEvent record: ${err.message}`)
+      console.error(`failed to extract S3Event record from SNSEvent record: ${err.message}`, snsRec)
     }
   }
   return s3Event

--- a/test/test.spec.mjs
+++ b/test/test.spec.mjs
@@ -37,10 +37,17 @@ test('creates an index on put', async t => {
 
   await handler({
     Records: [{
-      eventName: 'ObjectCreated:Put',
-      s3: {
-        bucket: { name: 'test' },
-        object: { key: `${cid}.car` }
+      Sns: {
+        Message: JSON.stringify({
+          Records: [{
+            eventSource: 'aws:s3',
+            eventName: 'ObjectCreated:Put',
+            s3: {
+              bucket: { name: 'test' },
+              object: { key: `${cid}.car` }
+            }
+          }]
+        })
       }
     }]
   }, { clientContext: { Custom: { S3Client: MockS3Client } } })


### PR DESCRIPTION
This PR alters the handler to expect an `SNSEvent` instead of an `S3Event`.

The S3 bucket will now publish `PutObject:*` events to an SNS topic so that multiple services can subscribe.