### PR TITLE
feat: add retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { CarIndexer } = require('@ipld/car/indexer')
 const { Readable } = require('stream')
 
 const maxRetries = process.env.MAX_RETRIES ? parseInt(process.env.MAX_RETRIES) : 3
-const retryDelay = process.env.RETRY_DELAY ? parseInt(process.env.RETRY_DELAY) : 500
+const retryDelay = process.env.RETRY_DELAY ? parseInt(process.env.RETRY_DELAY) : 100
 
 /**
  * @type {import('aws-lambda').SNSHandler}
@@ -82,6 +82,8 @@ async function retry (fn) {
     } catch (err) {
       if (++attempts >= maxRetries) throw err
     }
-    await new Promise(resolve => setTimeout(resolve, retryDelay))
+    await sleep(retryDelay)
   }
 }
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const { MultihashIndexSortedWriter } = require('cardex')
 const { CarIndexer } = require('@ipld/car/indexer')
 const { Readable } = require('stream')
 
-const maxRetries = 3
-const retryDelay = 500
+const maxRetries = process.env.MAX_RETRIES ? parseInt(process.env.MAX_RETRIES) : 3
+const retryDelay = process.env.RETRY_DELAY ? parseInt(process.env.RETRY_DELAY) : 500
 
 /**
  * @type {import('aws-lambda').SNSHandler}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.100.0",
         "@ipld/car": "^4.1.3",
-        "cardex": "^0.0.0",
-        "uint8arrays": "^3.0.0"
+        "cardex": "^0.0.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.97",
         "ava": "^4.3.0",
         "multiformats": "^9.6.5",
-        "standard": "^17.0.0"
+        "standard": "^17.0.0",
+        "uint8arrays": "^3.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.100.0",
     "@ipld/car": "^4.1.3",
-    "cardex": "^0.0.0",
-    "uint8arrays": "^3.0.0"
+    "cardex": "^0.0.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.97",
     "ava": "^4.3.0",
     "multiformats": "^9.6.5",
-    "standard": "^17.0.0"
+    "standard": "^17.0.0",
+    "uint8arrays": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds retry capability and retries the operation up to 3 times, with 500ms delay (by default).

Also switches to streaming the index to S3 instead of buffering it.